### PR TITLE
Use AutoDoc to generate the manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 doc/*
 !doc/*.xml
 !doc/*.bib
+doc/_*.xml
+

--- a/makedoc.g
+++ b/makedoc.g
@@ -1,8 +1,15 @@
-MakeGAPDocDoc(
-  "doc",
-  "manual.xml",
-  ["../PackageInfo.g"],
-  "ModularGroup"
-);;
-CopyHTMLStyleFiles("doc");
+##  this creates the documentation, needs: GAPDoc and AutoDoc packages, pdflatex
+##
+##  Call this with GAP from within the package directory.
+##
+if fail = LoadPackage("AutoDoc", ">= 2019.04.10") then
+    Error("AutoDoc 2019.04.10 or newer is required");
+fi;
+
+AutoDoc(rec(
+    gapdoc := rec(main := "manual.xml"),
+    scaffold := false,
+    autodoc := true,
+    #extract_examples := true,
+));
 QUIT;


### PR DESCRIPTION
This brings various benefits and e.g. helped find and fix the issues resolved by PRs #6 and #7 (by enabling the `extract_examples := true` and checking the test results -- I deliberately don't do that here, as obviously it would cause CI to fail if the fix PRs are not merged first).

In the future the `scaffold` feature could also be turned on to replace `doc/manual.xml` by auto-generated XML which draws its data from `PackageInfo.g` (meaning the lists of authors, titles etc. only need to be maintained in a single place and can't go out of sync by accident). But this is optional.

